### PR TITLE
chore: upgrade takumi-js from 2.0.0-beta.6 to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-dom": "19.2.4",
     "react-hook-form": "^7.71.2",
     "react-icons": "^5.6.0",
-    "takumi-js": "2.0.0-beta.6"
+    "takumi-js": "^2.2.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^5.6.0
         version: 5.6.0(react@19.2.4)
       takumi-js:
-        specifier: 2.0.0-beta.6
-        version: 2.0.0-beta.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^2.2.0
+        version: 2.2.0(csstype@3.2.3)(react@19.2.4)
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.7
@@ -617,75 +617,87 @@ packages:
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
-  '@takumi-rs/core-darwin-arm64@2.0.0-beta.6':
-    resolution: {integrity: sha512-EDNn44Xk+hMlYX2yK1cBwzic5oh2rL8HsHPG3a1/tAPdzIkSRlAnD+A6+t1G2F4TgfW2Sf65AV/848k3xkUr7g==}
-    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+  '@takumi-rs/core-darwin-arm64@2.2.0':
+    resolution: {integrity: sha512-6HhAaf63mrjX+q3yQXX0SZVU18kSuzr35nAcTsqqKGIr/jsoUMAygiLRDTaufpSlCo7lL4TkUmcIi8/vl3fHVg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@takumi-rs/core-darwin-x64@2.0.0-beta.6':
-    resolution: {integrity: sha512-Z5r887Al1bv7+BOvXmxwT/uyeK+0tkd7J3Cs39sV2AjVT2iISaopI1bdWymjKYQ1mUQuhQkJPIPitwuv8/oSpA==}
-    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+  '@takumi-rs/core-darwin-x64@2.2.0':
+    resolution: {integrity: sha512-JSv1m+9m3xxCBfJFQ29ACU+ITHV0avDj5LQTOLdmIifRBv4x+JogjWw2ZRq5PisJ8/vKA/QklDqOGeJhxHcw2g==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@takumi-rs/core-linux-arm64-gnu@2.0.0-beta.6':
-    resolution: {integrity: sha512-umQI5bHt2d9h1Sf/chnU7r94sxu315OCpwEY/hxmEeb2a6DP0X4gP3uScFU4lTnQm1+08Tf7uFG1I0Bp27Ephg==}
-    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+  '@takumi-rs/core-linux-arm64-gnu@2.2.0':
+    resolution: {integrity: sha512-fXWs3q8iJiSToCvgjv2/9h8/3FxmBB5ba32mNOoFP+zD8kEQDNYoQ/TfLUqDWoGTVPvjGL+SLwp3PxydFa1Nfw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@takumi-rs/core-linux-arm64-musl@2.0.0-beta.6':
-    resolution: {integrity: sha512-1BU/eyXie7xn05pPPy/YlsG/21uNPeMNzLJQq4KsYZFR2Bq7Omkv73fbJBIz8NOVWcQTto4b5/si9iAmlxztHg==}
-    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+  '@takumi-rs/core-linux-arm64-musl@2.2.0':
+    resolution: {integrity: sha512-O+FBMMAXK7r57oVH6dFhZ+4clWRtZ6LeIpzLsAz8FFYU4c9cwGoTBJ8BideNJzt2S78GDQaG9qy5wM+pvkveYA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@takumi-rs/core-linux-x64-gnu@2.0.0-beta.6':
-    resolution: {integrity: sha512-pMDrtS6H/+hzwJ24p/rF6VaVQRz8ZOzwnvXNJtt0bp9UdRbvigHv7QikQjX7UWxd/LEMQbJmynGzJTtAULLlOQ==}
-    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+  '@takumi-rs/core-linux-x64-gnu@2.2.0':
+    resolution: {integrity: sha512-zRy83L9R0SIr0t4AcRzpmbRhCQsB/XZzgjDJ/szA3dytX9jDtVP1WpcoyFRBJFTrmXDFsAIEBoKTobV5vs427w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@takumi-rs/core-linux-x64-musl@2.0.0-beta.6':
-    resolution: {integrity: sha512-CGXZaffvTHnVoiMznEK8xlRDA62OtOaXbU+Eg6bRveunQH8wPQKgX6NpCVsM2EIg3DgZQusG+AXHwJ0Sr5UGJA==}
-    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+  '@takumi-rs/core-linux-x64-musl@2.2.0':
+    resolution: {integrity: sha512-K+14jFA7XQXdrMu3gOToIzZvcP6DK0f0FZMH3HQ7bQfRn1Hx9gS1KesILjpH/C4CF+ZK5kQhxwVjoxeUzBSeYA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@takumi-rs/core-win32-arm64-msvc@2.0.0-beta.6':
-    resolution: {integrity: sha512-JYfie7rYaWC9RkwGKeFVfRoA61vqO/7dtlH4qMsZuWxX/vg5lAp0oa7aJv5cgnJ/B0a3DcJsVr+Vss8gxyb0TQ==}
-    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+  '@takumi-rs/core-win32-arm64-msvc@2.2.0':
+    resolution: {integrity: sha512-CPIVzIMCcTP6Bd9TDn1eB6NNwMViIRjyOCexH2fdJj3/rzfp0/A1EDkfFMXMmItFomwGpe7f/2I0A5Vvujnzbg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@takumi-rs/core-win32-x64-msvc@2.0.0-beta.6':
-    resolution: {integrity: sha512-A90k8uao+eW/4UM45SE391bDUQdTIdDkjMf38mmD8H9ppeTgN80twzh7MKZxVGGUxzWzLO+BklVRE3a/S8hqEQ==}
-    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+  '@takumi-rs/core-win32-x64-msvc@2.2.0':
+    resolution: {integrity: sha512-IATwTX+ScVtHECIAUw7+xXZmu/lCZylHHCNzpIQUnzAxRjT3iu9E8WHQvNlCtxDnYq1L3AhuuwmJoh+2cT7BaA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  '@takumi-rs/core@2.0.0-beta.6':
-    resolution: {integrity: sha512-iR/DFUdj1vzpT4hzFhYghen7aWXj+/XK57Qg0+hF4q+XW5+bkf/OAvYh6ofniamD59dagTUwHqsYHNuWlx55VQ==}
-    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
-
-  '@takumi-rs/helpers@2.0.0-beta.6':
-    resolution: {integrity: sha512-IwYPscOJYUlGqVzhFiBrzsbZIZmD7BwO+3UPJafR6zPHjAldkTrj/bGnaXFEYXMVKKHUfHikMppBujpeJ+nO+Q==}
+  '@takumi-rs/core@2.2.0':
+    resolution: {integrity: sha512-Ex393O45Su8Xm0DqqtFPDnhF93neUzUX5JlVmJ4R95dVY7NQyJkAJ2kZ/Uok8EyWI92G5AEFlkglarrkP3/jwQ==}
+    engines: {node: '>=18'}
     peerDependencies:
-      react: ^19.2.5
-      react-dom: ^18.0.0 || ^19.0.0
+      csstype: '*'
     peerDependenciesMeta:
+      csstype:
+        optional: true
+
+  '@takumi-rs/helpers@2.2.0':
+    resolution: {integrity: sha512-U9Cr4x/BN/GDFcmIOQs3XdiBQvidbv7rsSIjpol/ICN2EOvNaSnXMm9wwtBr4UgkQ2IhMzcTmkgrCMx8LROjwg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      preact: ^10.0.0
+      react: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      preact:
+        optional: true
       react:
         optional: true
-      react-dom:
-        optional: true
 
-  '@takumi-rs/wasm@2.0.0-beta.6':
-    resolution: {integrity: sha512-PUSa8p5b0IkvDQeSO0tc94Wr5j1fR6Eh+PaLZI0UPzveJMZN4uzPzZGL0AUu9+9yjA+AGWVD5AXIcGGjjnW2Mw==}
+  '@takumi-rs/wasm@2.2.0':
+    resolution: {integrity: sha512-6xizlgurJNkynwFZBI/ercSf2mlYryVgp0kl0KK6yV10rahs5ECVGH8TcSD9gtzi3YBnxCNkdD6oAw1K5+ApNA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      csstype: '*'
+    peerDependenciesMeta:
+      csstype:
+        optional: true
 
   '@types/lodash-es@4.17.12':
     resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
@@ -1102,10 +1114,12 @@ packages:
   conventional-changelog-atom@3.0.0:
     resolution: {integrity: sha512-pnN5bWpH+iTUWU3FaYdw5lJmfWeqSyrUkG+wyHBI9tC1dLNnHkbAOg1SzTQ7zBqiFrfo55h40VsGXWMdopwc5g==}
     engines: {node: '>=14'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-codemirror@3.0.0:
     resolution: {integrity: sha512-wzchZt9HEaAZrenZAUUHMCFcuYzGoZ1wG/kTRMICxsnW5AXohYMRxnyecP9ob42Gvn5TilhC0q66AtTPRSNMfw==}
     engines: {node: '>=14'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-config-spec@2.1.0:
     resolution: {integrity: sha512-IpVePh16EbbB02V+UA+HQnnPIohgXvJRxHcS5+Uwk4AT5LjzCZJm5sp/yqs5C6KZJ1jMsV4paEV13BN1pvDuxQ==}
@@ -1121,26 +1135,32 @@ packages:
   conventional-changelog-core@5.0.2:
     resolution: {integrity: sha512-RhQOcDweXNWvlRwUDCpaqXzbZemKPKncCWZG50Alth72WITVd6nhVk9MJ6w1k9PFNBcZ3YwkdkChE+8+ZwtUug==}
     engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-ember@3.0.0:
     resolution: {integrity: sha512-7PYthCoSxIS98vWhVcSphMYM322OxptpKAuHYdVspryI0ooLDehRXWeRWgN+zWSBXKl/pwdgAg8IpLNSM1/61A==}
     engines: {node: '>=14'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-eslint@4.0.0:
     resolution: {integrity: sha512-nEZ9byP89hIU0dMx37JXQkE1IpMmqKtsaR24X7aM3L6Yy/uAtbb+ogqthuNYJkeO1HyvK7JsX84z8649hvp43Q==}
     engines: {node: '>=14'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-express@3.0.0:
     resolution: {integrity: sha512-HqxihpUMfIuxvlPvC6HltA4ZktQEUan/v3XQ77+/zbu8No/fqK3rxSZaYeHYant7zRxQNIIli7S+qLS9tX9zQA==}
     engines: {node: '>=14'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-jquery@4.0.0:
     resolution: {integrity: sha512-TTIN5CyzRMf8PUwyy4IOLmLV2DFmPtasKN+x7EQKzwSX8086XYwo+NeaeA3VUT8bvKaIy5z/JoWUvi7huUOgaw==}
     engines: {node: '>=14'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-jshint@3.0.0:
     resolution: {integrity: sha512-bQof4byF4q+n+dwFRkJ/jGf9dCNUv4/kCDcjeCizBvfF81TeimPZBB6fT4HYbXgxxfxWXNl/i+J6T0nI4by6DA==}
     engines: {node: '>=14'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-preset-loader@3.0.0:
     resolution: {integrity: sha512-qy9XbdSLmVnwnvzEisjxdDiLA4OmV3o8db+Zdg4WiFw14fP3B6XNz98X0swPPpkTd/pc1K7+adKgEDM1JCUMiA==}
@@ -1348,12 +1368,13 @@ packages:
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -1363,7 +1384,7 @@ packages:
   git-semver-tags@5.0.1:
     resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   gitconfiglocal@1.0.0:
@@ -2138,8 +2159,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  takumi-js@2.0.0-beta.6:
-    resolution: {integrity: sha512-ADngMcSfCbu/Cv57c/SQgDnnPYqhMdCSVh8O2mFJa/cImRAIV/uW6rOE3SLE0NK2k0jHHVUU4IV5xKGYa5pcZg==}
+  takumi-js@2.2.0:
+    resolution: {integrity: sha512-EGw1bJ1U/GfISJi5hs6G98dLfk1QId90z+buXrRTFs8MAJTHTxdno+0jX0eamzXueT8AGLfdI0nSq47Dw1uSUQ==}
+    engines: {node: '>=18'}
 
   text-extensions@1.9.0:
     resolution: {integrity: sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==}
@@ -2840,57 +2862,59 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@takumi-rs/core-darwin-arm64@2.0.0-beta.6':
+  '@takumi-rs/core-darwin-arm64@2.2.0':
     optional: true
 
-  '@takumi-rs/core-darwin-x64@2.0.0-beta.6':
+  '@takumi-rs/core-darwin-x64@2.2.0':
     optional: true
 
-  '@takumi-rs/core-linux-arm64-gnu@2.0.0-beta.6':
+  '@takumi-rs/core-linux-arm64-gnu@2.2.0':
     optional: true
 
-  '@takumi-rs/core-linux-arm64-musl@2.0.0-beta.6':
+  '@takumi-rs/core-linux-arm64-musl@2.2.0':
     optional: true
 
-  '@takumi-rs/core-linux-x64-gnu@2.0.0-beta.6':
+  '@takumi-rs/core-linux-x64-gnu@2.2.0':
     optional: true
 
-  '@takumi-rs/core-linux-x64-musl@2.0.0-beta.6':
+  '@takumi-rs/core-linux-x64-musl@2.2.0':
     optional: true
 
-  '@takumi-rs/core-win32-arm64-msvc@2.0.0-beta.6':
+  '@takumi-rs/core-win32-arm64-msvc@2.2.0':
     optional: true
 
-  '@takumi-rs/core-win32-x64-msvc@2.0.0-beta.6':
+  '@takumi-rs/core-win32-x64-msvc@2.2.0':
     optional: true
 
-  '@takumi-rs/core@2.0.0-beta.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@takumi-rs/core@2.2.0(csstype@3.2.3)(react@19.2.4)':
     dependencies:
-      '@takumi-rs/helpers': 2.0.0-beta.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@takumi-rs/helpers': 2.2.0(react@19.2.4)
     optionalDependencies:
-      '@takumi-rs/core-darwin-arm64': 2.0.0-beta.6
-      '@takumi-rs/core-darwin-x64': 2.0.0-beta.6
-      '@takumi-rs/core-linux-arm64-gnu': 2.0.0-beta.6
-      '@takumi-rs/core-linux-arm64-musl': 2.0.0-beta.6
-      '@takumi-rs/core-linux-x64-gnu': 2.0.0-beta.6
-      '@takumi-rs/core-linux-x64-musl': 2.0.0-beta.6
-      '@takumi-rs/core-win32-arm64-msvc': 2.0.0-beta.6
-      '@takumi-rs/core-win32-x64-msvc': 2.0.0-beta.6
+      '@takumi-rs/core-darwin-arm64': 2.2.0
+      '@takumi-rs/core-darwin-x64': 2.2.0
+      '@takumi-rs/core-linux-arm64-gnu': 2.2.0
+      '@takumi-rs/core-linux-arm64-musl': 2.2.0
+      '@takumi-rs/core-linux-x64-gnu': 2.2.0
+      '@takumi-rs/core-linux-x64-musl': 2.2.0
+      '@takumi-rs/core-win32-arm64-msvc': 2.2.0
+      '@takumi-rs/core-win32-x64-msvc': 2.2.0
+      csstype: 3.2.3
     transitivePeerDependencies:
+      - preact
       - react
-      - react-dom
 
-  '@takumi-rs/helpers@2.0.0-beta.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@takumi-rs/helpers@2.2.0(react@19.2.4)':
     optionalDependencies:
       react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
 
-  '@takumi-rs/wasm@2.0.0-beta.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@takumi-rs/wasm@2.2.0(csstype@3.2.3)(react@19.2.4)':
     dependencies:
-      '@takumi-rs/helpers': 2.0.0-beta.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@takumi-rs/helpers': 2.2.0(react@19.2.4)
+    optionalDependencies:
+      csstype: 3.2.3
     transitivePeerDependencies:
+      - preact
       - react
-      - react-dom
 
   '@types/lodash-es@4.17.12':
     dependencies:
@@ -4523,14 +4547,15 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  takumi-js@2.0.0-beta.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  takumi-js@2.2.0(csstype@3.2.3)(react@19.2.4):
     dependencies:
-      '@takumi-rs/core': 2.0.0-beta.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@takumi-rs/helpers': 2.0.0-beta.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@takumi-rs/wasm': 2.0.0-beta.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@takumi-rs/core': 2.2.0(csstype@3.2.3)(react@19.2.4)
+      '@takumi-rs/helpers': 2.2.0(react@19.2.4)
+      '@takumi-rs/wasm': 2.2.0(csstype@3.2.3)(react@19.2.4)
     transitivePeerDependencies:
+      - csstype
+      - preact
       - react
-      - react-dom
 
   text-extensions@1.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,15 @@
 allowBuilds:
   sharp: true
+minimumReleaseAgeExclude:
+  - '@takumi-rs/core-darwin-arm64@2.2.0'
+  - '@takumi-rs/core-darwin-x64@2.2.0'
+  - '@takumi-rs/core-linux-arm64-gnu@2.2.0'
+  - '@takumi-rs/core-linux-arm64-musl@2.2.0'
+  - '@takumi-rs/core-linux-x64-gnu@2.2.0'
+  - '@takumi-rs/core-linux-x64-musl@2.2.0'
+  - '@takumi-rs/core-win32-arm64-msvc@2.2.0'
+  - '@takumi-rs/core-win32-x64-msvc@2.2.0'
+  - '@takumi-rs/core@2.2.0'
+  - '@takumi-rs/helpers@2.2.0'
+  - '@takumi-rs/wasm@2.2.0'
+  - takumi-js@2.2.0


### PR DESCRIPTION
## Summary

Upgrades the OG image rendering engine from beta to latest stable release (2.2.0). The project uses the stable `ImageResponse` API from `takumi-js/response`, which has no breaking changes between beta.6 and 2.2.0.

## Changes

| File | What changed | Why |
|---|---|---|
| `package.json` | ~ `takumi-js` from `2.0.0-beta.6` to `^2.2.0` | Upgrade to latest stable version |
| `pnpm-lock.yaml` | ~ Lockfile regenerated | Reflects new resolution for takumi-js and `@takumi-rs/*` packages |
| `pnpm-workspace.yaml` | + `minimumReleaseAgeExclude` entries for `@takumi-rs/*` and `takumi-js` | Auto-added by pnpm for fresh installs within minimum release age window |

## Testing

- `pnpm dlx ultracite check` - 41 files checked, no issues
- `tsc --noEmit` - no type errors
- `next build` - compiled successfully
- Code review: approved