### PR TITLE
fix: add Dependabot cooldown and pnpm minimumReleaseAgeExclude

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 2
+      semver-major-days: 7
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

Dependabot PRs were failing on Vercel deployments with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`. pnpm 11 enforces a 24-hour minimum release age on packages, but Dependabot creates PRs as soon as new versions are published.

## Changes

| File | Change | Why |
|------|--------|-----|
| `.github/dependabot.yml` | + Added cooldown (default-days: 2, semver-major-days: 7) | Prevents Dependabot from opening PRs for packages under 2 days old -- safely past pnpm's 24h policy window |

## Testing

- Dependabot will now wait 2 days before creating PRs, giving packages time to age past the 24h window